### PR TITLE
Suppress unused function warnings

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -147,6 +147,8 @@ zephyr_library_compile_definitions(
 )
 
 # patch around warnings in third-party files
+zephyr_library_compile_options( -Wno-unused-function )
+
 set_source_files_properties(
     ${SRC}/crypto_pwhash/argon2/pwhash_argon2i.c
     ${SRC}/crypto_pwhash/argon2/argon2-core.c


### PR DESCRIPTION
When building a Zephyr application, Libsodium spits out dozens of warnings like this one:
```
/home/jamie/bes/project/embedded-link/elink-sdk/modules/crypto/libsodium/zephyr/../libsodium/src/libsodium/include/sodium/private/ed25519_ref10_fe_25_5.h:982:1: warning: 'fe25519_scalar_product' defined but not used [-Wunused-function]
  982 | fe25519_scalar_product(fe25519 h, const fe25519 f, uint32_t n)
      | ^~~~~~~~~~~~~~~~~~~~~~
```
They cause the build output to be extremely verbose and make it difficult to see real compile warnings/errors from the application itself. I had a local change for a while to disable these warnings, but I'd like to get it merged on the remote so the local change isn't necessary.