### PR TITLE
Update libsodium ssubmodule URL to HTTPS for CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libsodium"]
 	path = libsodium
-	url = git@github.com:bes-org/libsodium.git
+	url = https://github.com/bes-org/libsodium.git


### PR DESCRIPTION
github's action's docker prefers git url's specified with HTTPS: 

[Failing build](https://github.com/bes-elink/elink-sdk/actions/runs/6950467725/job/18942153792#step:5:2283) (will get stuck when cloning the repo)